### PR TITLE
frida 17 breaking changes fix

### DIFF
--- a/Helpers/script.js
+++ b/Helpers/script.js
@@ -107,7 +107,11 @@ function inject(lib, process_name){
 
 function Hooker(lib, process_name) {
     const name = lib['name'];
-    Module.enumerateExportsSync(name).forEach(function(exp){
+    const entries = (parseInt(Frida.version) >= 17 && mod.enumerateSymbols) 
+      ? mod.enumerateSymbols() 
+      : Module.enumerateExportsSync(moduleName);
+  
+    entries.forEach(function(exp){
         try {
             var module_address = exp.address;
             if (exp.name === '_lcc00' || exp.name === '_oecc00') {


### PR DESCRIPTION
Check if ``Frida.version`` is equal or bigger than ``17``. If it is, then use ``Process.getModuleByName(name).enumerateSymbols()``. If not, stick back to the old ``Module.enumerateSymbolsSync(name)``